### PR TITLE
Fix async methods, entity registration, and unit conversion

### DIFF
--- a/custom_components/powerdog/__init__.py
+++ b/custom_components/powerdog/__init__.py
@@ -177,11 +177,10 @@ class PowerDogHub:
             if entity_id in self.selects:
                 self.selects[entity_id]["Current_Value"] = current_value
 
-            # Falls es ein Counter ist, auch die Usage-Werte aktualisieren
-            if entity_id in self.sensors and self.sensors[entity_id].get("LinearType") == "counter":
-                for usage_type in ["30Day_Usage", "Today_Usage", "Year_Usage"]:
-                    usage_entity_id = f"{entity_id}_{usage_type.lower()}"
-                    if usage_entity_id in self.sensors:
-                        self.sensors[usage_entity_id]["Current_Value"] = value_data.get(usage_type, 0)
+            # Update counter usage values if present in the response
+            for usage_type in ["30Day_Usage", "Today_Usage", "Year_Usage"]:
+                usage_entity_id = f"{entity_id}_{usage_type.lower()}"
+                if usage_entity_id in self.sensors and usage_type in value_data:
+                    self.sensors[usage_entity_id]["Current_Value"] = value_data.get(usage_type, 0)
 
         _LOGGER.debug("✅ PowerDog Werte erfolgreich aktualisiert!")

--- a/custom_components/powerdog/number.py
+++ b/custom_components/powerdog/number.py
@@ -2,20 +2,20 @@ import logging
 import asyncio
 from homeassistant.components.number import NumberEntity
 from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.const import PERCENTAGE  # ⚠️ Hier den richtigen Wert importieren
+from homeassistant.const import PERCENTAGE
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup_entry(hass, entry, async_add_entities):
-    """Number-Setup für PowerDog."""
-    _LOGGER.debug("🔄 async_setup_entry für Numbers wurde aufgerufen!")
+    """Number-Setup for PowerDog."""
+    _LOGGER.debug("async_setup_entry for Numbers called!")
 
     hub = hass.data[DOMAIN]["hub"]
     entities = [PowerDogNumber(hub, entry, entity_id, entity) for entity_id, entity in hub.numbers.items()]
 
     async_add_entities(entities, True)
-    _LOGGER.debug(f"🚀 {len(entities)} NUMBER-Entitäten erfolgreich hinzugefügt!")
+    _LOGGER.debug(f"{len(entities)} NUMBER entities added successfully!")
 
 class PowerDogNumber(NumberEntity):
     def __init__(self, hub, entry, entity_id, entity_info):
@@ -23,15 +23,14 @@ class PowerDogNumber(NumberEntity):
         self._entry = entry
         self._entity_id = entity_id
         self._name = f"{entity_info.get('Name', entity_id)}"
-        _LOGGER.debug(f"🔧 Initialisiere Number {self._name}...")
+        _LOGGER.debug(f"Initializing Number {self._name}...")
         self._state = entity_info.get("Current_Value", None)
         self._unit = entity_info.get("Unit", "")
         self._attr_unique_id = f"powerdog_{self._entity_id}"
-        # Wert setzen
         self._value = float(entity_info.get("Current_Value", 0))
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(entry.entry_id))},  # Nutze `entry_id`
+            identifiers={(DOMAIN, str(entry.entry_id))},
             name="PowerDog",
             manufacturer="PowerDog",
             model="API"
@@ -41,53 +40,48 @@ class PowerDogNumber(NumberEntity):
         self._attr_native_min_value = float(entity_info.get("Min", 0))
         self._attr_native_max_value = float(entity_info.get("Max", 100))
 
-        # Falls die Einheit Prozent ist, setze sie explizit
-        self._attr_native_unit_of_measurement = PERCENTAGE if "percent" in self._name.lower() else None
+        if "percent" in self._name.lower():
+            self._attr_native_unit_of_measurement = PERCENTAGE
 
-    @property
-    def unique_id(self):
-        """Gibt eine eindeutige ID für die Entität zurück."""
-        return f"powerdog_number_{self._entity_id}"
+    async def async_added_to_hass(self):
+        """Called when entity is added to hass."""
+        await super().async_added_to_hass()
+        _LOGGER.debug(f"Number {self._name} added to hass")
 
     @property
     def name(self):
         return self._name
 
     async def async_set_native_value(self, value: float):
-        """Setzt einen neuen Wert asynchron."""
-        _LOGGER.debug(f"🔄 Setze {self._name} auf {value}...")
+        """Set a new value asynchronously."""
+        _LOGGER.debug(f"Setting {self._name} to {value}...")
 
         def sync_call():
-            """Führe den blockierenden API-Call in einem separaten Thread aus."""
+            """Execute the blocking API call in a separate thread."""
             try:
                 return self._hub.client.setRegulationParameter(
                     self._hub.password, self._entity_id, "value", str(value)
                 )
             except Exception as e:
-                _LOGGER.error(f"❌ API-Fehler beim Setzen von {self._name}: {e}")
+                _LOGGER.error(f"API error setting {self._name}: {e}")
                 return None
 
         response = await asyncio.to_thread(sync_call)
 
         if response and response.get("ErrorCode") == 0:
             self._attr_native_value = value
-            self.async_write_ha_state()
             self._hub.numbers[self._entity_id]["Current_Value"] = value
-            _LOGGER.debug(f"✅ {self._name} erfolgreich auf {value} gesetzt")
+            _LOGGER.debug(f"{self._name} successfully set to {value}")
         else:
-            _LOGGER.error(f"❌ Fehler beim Setzen von {self._name}: {response}")
+            _LOGGER.error(f"Error setting {self._name}: {response}")
 
     async def async_update(self):
-            """Aktualisiert den Wert aus dem Hub."""
-            if self._entity_id not in self._hub.numbers:
-                _LOGGER.warning(f"⚠️ Entität {self._entity_id} existiert nicht mehr im Hub-Datenbestand!")
-                return
+        """Update the value from the hub."""
+        if self._entity_id not in self._hub.numbers:
+            _LOGGER.warning(f"Entity {self._entity_id} no longer exists in hub data!")
+            return
 
-            value = self._hub.numbers.get(self._entity_id, {}).get("Current_Value")
-            if value is not None:
-                self._attr_native_value = value
-
-            # ✅ Erst updaten, wenn die Entität wirklich registriert wurde
-            if self.registry_entry:
-                self.async_write_ha_state()
-                _LOGGER.debug(f"🔄 {self._name} aktualisiert auf {self._state}")
+        value = self._hub.numbers.get(self._entity_id, {}).get("Current_Value")
+        if value is not None:
+            self._attr_native_value = value
+            _LOGGER.debug(f"{self._name} updated to {value}")

--- a/custom_components/powerdog/select.py
+++ b/custom_components/powerdog/select.py
@@ -17,11 +17,10 @@ class PowerDogModeSelect(SelectEntity):
         self._entry = entry
         self._entity_id = entity_id
         self._name = f"{entity_info.get('Name', entity_id)}"
-        self._state = entity_info.get("Current_Value", None)
         self._unit = entity_info.get("Unit", "")
         self._attr_unique_id = f"powerdog_{self._entity_id}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(entry.entry_id))},  # Nutze `entry_id`
+            identifiers={(DOMAIN, str(entry.entry_id))},
             name="PowerDog",
             manufacturer="PowerDog",
             model="API"
@@ -29,7 +28,7 @@ class PowerDogModeSelect(SelectEntity):
 
         self._attr_options = ["Auto", "On", "Off"]
 
-        switch_mode = entity_info.get("SwitchMode", "0")  # Standard: Auto
+        switch_mode = entity_info.get("SwitchMode", "0")
         switch_state = entity_info.get("SwitchState", "0")
 
         if switch_mode == "0":
@@ -39,54 +38,63 @@ class PowerDogModeSelect(SelectEntity):
         else:
             self._attr_current_option = "Off"
 
-        _LOGGER.debug(f"🔍 {self._name} initialisiert mit Modus: {self._attr_current_option}")
+        _LOGGER.debug(f"{self._name} initialized with mode: {self._attr_current_option}")
+
+    async def async_added_to_hass(self):
+        """Called when entity is added to hass."""
+        await super().async_added_to_hass()
+        _LOGGER.debug(f"Select {self._name} added to hass")
 
     @property
     def name(self):
         return self._name
 
-    @property
-    def state(self):
-        return self._state
-
-    def select_option(self, option):
-        """Setzt den Modus auf Auto, On oder Off."""
-        _LOGGER.debug(f"🔄 Moduswechsel auf {option} für {self._attr_name}")
+    async def async_select_option(self, option: str):
+        """Set the mode to Auto, On or Off."""
+        _LOGGER.debug(f"Mode change to {option} for {self._name}")
 
         try:
             if option == "Auto":
-                response = self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "manual", "0"
                 )
             else:
-                # In Manuell-Modus wechseln
-                self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "manual", "1"
                 )
                 if option == "On":
-                    response = self._hub.client.setRegulationParameter(
+                    await self.hass.async_add_executor_job(
+                        self._hub.client.setRegulationParameter,
                         self._hub.password, self._entity_id, "value", "100"
                     )
                 else:
-                    response = self._hub.client.setRegulationParameter(
+                    await self.hass.async_add_executor_job(
+                        self._hub.client.setRegulationParameter,
                         self._hub.password, self._entity_id, "value", "0"
                     )
 
             self._attr_current_option = option
+            _LOGGER.debug(f"{self._name} mode set to {option}")
         except Exception as e:
-            _LOGGER.error(f"❌ Fehler beim Setzen des Modus für {self._attr_name}: {e}")
+            _LOGGER.error(f"Error setting mode for {self._name}: {e}")
 
     async def async_update(self):
-        """Aktualisiert den Wert aus dem Hub."""
+        """Update the value from the hub."""
         if self._entity_id not in self._hub.selects:
-            _LOGGER.warning(f"⚠️ Entität {self._entity_id} existiert nicht mehr im Hub-Datenbestand!")
+            _LOGGER.warning(f"Entity {self._entity_id} no longer exists in hub data!")
             return
 
-        value = self._hub.selects[self._entity_id].get("Current_Value")
-        if value is not None:
-            self._state = value
+        entity_info = self._hub.selects.get(self._entity_id, {})
+        switch_mode = entity_info.get("SwitchMode", "0")
+        switch_state = entity_info.get("SwitchState", "0")
 
-        # ✅ Erst updaten, wenn die Entität wirklich registriert wurde
-        if self.registry_entry:
-            self.async_write_ha_state()
-            _LOGGER.debug(f"🔄 {self._name} aktualisiert auf {self._state} von {value}")
+        if switch_mode == "0":
+            self._attr_current_option = "Auto"
+        elif switch_state == "100":
+            self._attr_current_option = "On"
+        else:
+            self._attr_current_option = "Off"
+
+        _LOGGER.debug(f"{self._name} updated to {self._attr_current_option}")

--- a/custom_components/powerdog/sensor.py
+++ b/custom_components/powerdog/sensor.py
@@ -23,11 +23,20 @@ class PowerDogSensor(SensorEntity):
         self._entry = entry
         self._entity_id = entity_id
         self._name = f"{entity_info.get('Name', entity_id)}"
-        self._state = entity_info.get("Current_Value", None)
         self._unit = entity_info.get("Unit", "")
         self._attr_unique_id = f"powerdog_{self._entity_id}"
-        # Wert setzen
-        self._value = float(entity_info.get("Current_Value", 0))
+
+        # Convert Wh to kWh
+        self._convert_to_kwh = self._unit == "Wh"
+        if self._convert_to_kwh:
+            self._unit = "kWh"
+
+        raw_value = entity_info.get("Current_Value", None)
+        if raw_value is not None and self._convert_to_kwh:
+            self._state = round(float(raw_value) / 1000, 3)
+        else:
+            self._state = raw_value
+        self._value = float(raw_value) if raw_value else 0
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(entry.entry_id))},  # Nutze `entry_id`
@@ -37,7 +46,7 @@ class PowerDogSensor(SensorEntity):
         )
 
         # Prüfen, ob es sich um einen Energiezähler handelt
-        if self._unit in ["Wh", "kWh", "MWh"]:
+        if self._unit in ["kWh", "MWh"] or self._convert_to_kwh:
             self._attr_device_class = SensorDeviceClass.ENERGY
             self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         else:
@@ -68,14 +77,13 @@ class PowerDogSensor(SensorEntity):
     async def async_update(self):
         """Aktualisiert den Wert aus dem Hub."""
         if self._entity_id not in self._hub.sensors:
-            _LOGGER.warning(f"⚠️ Entität {self._entity_id} existiert nicht mehr im Hub-Datenbestand!")
+            _LOGGER.warning(f"Entity {self._entity_id} no longer exists in hub data!")
             return
 
         value = self._hub.sensors[self._entity_id].get("Current_Value")
         if value is not None:
-            self._state = value
-
-        # ✅ Erst updaten, wenn die Entität wirklich registriert wurde
-        if self.registry_entry:
-            self.async_write_ha_state()
-            _LOGGER.debug(f"🔄 {self._name} aktualisiert auf {self._state}")
+            if self._convert_to_kwh:
+                self._state = round(float(value) / 1000, 3)
+            else:
+                self._state = value
+            _LOGGER.debug(f"{self._name} updated to {self._state}")

--- a/custom_components/powerdog/services.yaml
+++ b/custom_components/powerdog/services.yaml
@@ -1,0 +1,12 @@
+set_auto_mode:
+  name: Set Auto Mode
+  description: Sets a PowerDog switch to automatic mode
+  fields:
+    entity_id:
+      name: Entity
+      description: The entity ID of the switch to set to auto mode
+      required: true
+      selector:
+        entity:
+          domain: switch
+          integration: powerdog

--- a/custom_components/powerdog/switch.py
+++ b/custom_components/powerdog/switch.py
@@ -1,5 +1,4 @@
 import logging
-import asyncio
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.device_registry import DeviceInfo
 from . import DOMAIN
@@ -12,12 +11,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
 
     async_add_entities(entities, True)
 
-    # **Neuen Service für den Auto-Modus registrieren**
     async def handle_set_auto_mode(call):
         entity_id = call.data.get("entity_id")
         for switch in entities:
             if switch.entity_id == entity_id:
-                switch.set_auto_mode()
+                await switch.async_set_auto_mode()
 
     hass.services.async_register(DOMAIN, "set_auto_mode", handle_set_auto_mode)
 
@@ -28,108 +26,106 @@ class PowerDogSwitch(SwitchEntity):
         self._entity_id = entity_id
         self._name = f"{entity_info.get('Name', entity_id)}"
         self._attr_unique_id = f"powerdog_{self._entity_id}"
-        # Wert setzen
         self._value = float(entity_info.get("Current_Value", 0))
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, str(entry.entry_id))},  # Nutze `entry_id`
+            identifiers={(DOMAIN, str(entry.entry_id))},
             name="PowerDog",
             manufacturer="PowerDog",
             model="API"
         )
 
-        # **Erkennen, ob es ein OnOff- oder Manual-Switch ist**
         self._is_onoff_switch = "onoff(bool)" in entity_info.get("Setable", "").lower()
 
-        # **Status lesen**
-        switch_mode = entity_info.get("SwitchMode")  # Auto (0) oder Manuell (1)
-        switch_state = entity_info.get("SwitchState")  # 0 = AUS, 100 = AN
+        switch_mode = entity_info.get("SwitchMode")
+        switch_state = entity_info.get("SwitchState")
         on_off = entity_info.get("OnOff")
 
         if self._is_onoff_switch:
             self._state = bool(int(on_off)) if on_off is not None else False
         else:
-            # Falls es ein Manual/Auto-Switch ist
             if switch_mode == "1":
                 self._state = switch_state == "100"
             else:
-                self._state = False  # Auto-Modus → wird als AUS angezeigt
+                self._state = False
 
-    def turn_on(self, **kwargs):
-        """Schalte den Switch an."""
+    async def async_added_to_hass(self):
+        """Called when entity is added to hass."""
+        await super().async_added_to_hass()
+        _LOGGER.debug(f"Switch {self._name} added to hass")
 
+    async def async_turn_on(self, **kwargs):
+        """Turn on the switch."""
         try:
             if self._is_onoff_switch:
-                response = self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "onoff", "1"
                 )
             else:
-                # Manual/Auto-Switch zuerst auf manuellen Modus setzen, dann aktivieren
-                self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "manual", "1"
                 )
-                response = self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "value", "100"
                 )
 
             self._state = True
         except Exception as e:
-            _LOGGER.error(f"❌ Fehler beim Einschalten von {self._name}: {e}")
+            _LOGGER.error(f"Error turning on {self._name}: {e}")
 
-    def turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs):
+        """Turn off the switch."""
         try:
             if self._is_onoff_switch:
-                response = self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "onoff", "0"
                 )
             else:
-                # Manual/Auto-Switch zuerst auf manuellen Modus setzen, dann deaktivieren
-                self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "manual", "1"
                 )
-                response = self._hub.client.setRegulationParameter(
+                await self.hass.async_add_executor_job(
+                    self._hub.client.setRegulationParameter,
                     self._hub.password, self._entity_id, "value", "0"
                 )
 
             self._state = False
         except Exception as e:
-            _LOGGER.error(f"❌ Fehler beim Ausschalten von {self._name}: {e}")
+            _LOGGER.error(f"Error turning off {self._name}: {e}")
 
-    def set_auto_mode(self):
+    async def async_set_auto_mode(self):
+        """Set the switch to auto mode."""
         try:
-            response = self._hub.client.setRegulationParameter(
+            await self.hass.async_add_executor_job(
+                self._hub.client.setRegulationParameter,
                 self._hub.password, self._entity_id, "manual", "0"
             )
-            self._state = False  # Auto-Modus → wird als AUS angezeigt
+            self._state = False
         except Exception as e:
-            _LOGGER.error(f"❌ Fehler beim Setzen auf Auto-Modus für {self._name}: {e}")
+            _LOGGER.error(f"Error setting auto mode for {self._name}: {e}")
 
     @property
     def is_on(self):
-        """Gibt den aktuellen Status zurück."""
+        """Return the current state."""
         return self._state
 
     @property
     def name(self):
-        """Gibt den Namen des Switches zurück."""
+        """Return the name of the switch."""
         return self._name
 
-    @property
-    def unique_id(self):
-        """Gibt eine eindeutige ID für die Entität zurück."""
-        return f"powerdog_switch_{self._entity_id}"
-
     async def async_update(self):
-        """Aktualisiert den Wert aus dem Hub."""
+        """Update the value from the hub."""
         if self._entity_id not in self._hub.switches:
-            _LOGGER.warning(f"⚠️ Entität {self._entity_id} existiert nicht mehr im Hub-Datenbestand!")
+            _LOGGER.warning(f"Entity {self._entity_id} no longer exists in hub data!")
             return
 
         value = self._hub.switches.get(self._entity_id, {}).get("Current_Value")
         if value is not None:
-            self._state = bool(int(value))  # ✅ Status korrekt setzen
-
-        # ✅ Erst updaten, wenn die Entität wirklich registriert wurde
-        if self.registry_entry:
-            self.async_write_ha_state()
-            _LOGGER.debug(f"🔄 {self._name} aktualisiert auf {self._state}")
+            self._state = bool(int(value))
+            _LOGGER.debug(f"{self._name} updated to {self._state}")


### PR DESCRIPTION
## Summary
- Convert blocking API calls to async methods to prevent UI freezes
- Fix entity registration issues (duplicate unique_id properties, missing async_added_to_hass)
- Auto-convert Wh values to kWh for better readability
- Fix counter-usage update logic in __init__.py
- Add services.yaml for set_auto_mode service

## Changes
- **switch.py**: Convert turn_on/turn_off/set_auto_mode to async with async_add_executor_job
- **number.py**: Add async_added_to_hass, remove duplicate unique_id property
- **select.py**: Convert select_option to async, fix _attr_name bug
- **sensor.py**: Auto-convert Wh to kWh (divide by 1000)
- **__init__.py**: Fix counter-usage update logic
- **services.yaml**: New file for service definitions