### PR TITLE
Add type prefixes to unique_ids

### DIFF
--- a/custom_components/powerdog/number.py
+++ b/custom_components/powerdog/number.py
@@ -26,7 +26,7 @@ class PowerDogNumber(NumberEntity):
         _LOGGER.debug(f"Initializing Number {self._name}...")
         self._state = entity_info.get("Current_Value", None)
         self._unit = entity_info.get("Unit", "")
-        self._attr_unique_id = f"powerdog_{self._entity_id}"
+        self._attr_unique_id = f"powerdog_number_{self._entity_id}"
         self._value = float(entity_info.get("Current_Value", 0))
 
         self._attr_device_info = DeviceInfo(

--- a/custom_components/powerdog/select.py
+++ b/custom_components/powerdog/select.py
@@ -18,7 +18,7 @@ class PowerDogModeSelect(SelectEntity):
         self._entity_id = entity_id
         self._name = f"{entity_info.get('Name', entity_id)}"
         self._unit = entity_info.get("Unit", "")
-        self._attr_unique_id = f"powerdog_{self._entity_id}"
+        self._attr_unique_id = f"powerdog_select_{self._entity_id}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(entry.entry_id))},
             name="PowerDog",

--- a/custom_components/powerdog/switch.py
+++ b/custom_components/powerdog/switch.py
@@ -25,7 +25,7 @@ class PowerDogSwitch(SwitchEntity):
         self._entry = entry
         self._entity_id = entity_id
         self._name = f"{entity_info.get('Name', entity_id)}"
-        self._attr_unique_id = f"powerdog_{self._entity_id}"
+        self._attr_unique_id = f"powerdog_switch_{self._entity_id}"
         self._value = float(entity_info.get("Current_Value", 0))
 
         self._attr_device_info = DeviceInfo(


### PR DESCRIPTION
## Summary
Adds type-specific prefixes to unique_ids to prevent duplicate entities when the same regulation appears in multiple platforms (switch, number, select).

## Changes
- switch.py: `powerdog_{id}` → `powerdog_switch_{id}`
- number.py: `powerdog_{id}` → `powerdog_number_{id}`
- select.py: `powerdog_{id}` → `powerdog_select_{id}`

## Why
When a regulation has multiple capabilities (e.g. onoff + manual + value), it gets registered in multiple platforms. Without unique prefixes, this caused duplicate entities with `_2` suffix.